### PR TITLE
fix: use browser-local YYYY-MM-DD date with 'en-CA' formatting

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -356,7 +356,10 @@ function buildHeatmapArea(aggregates, year, units, colors, type, layout, options
   grid.className = "grid";
 
   for (let day = new Date(start); day <= end; day.setDate(day.getDate() + 1)) {
-    const dateStr = day.toISOString().slice(0, 10);
+    // Get the local browser date in YYYY-MM-DD format.
+    // We use 'en-CA' locale because it outputs ISO-like format (year-month-day),
+    // while still using the browser's local time (not UTC).  
+    const dateStr = day.toLocaleDateString('en-CA'); 
     const inYear = day.getFullYear() === year;
     const entry = (aggregates && aggregates[dateStr]) || {
       count: 0,


### PR DESCRIPTION
Ensures the date string is in local browser time while keeping ISO-like format.

I am currently in Australia, the dow is off by one.

Before
<img width="322" height="274" alt="Screenshot 2026-02-06 at 11 26 13" src="https://github.com/user-attachments/assets/30354c6b-13c0-4876-a536-693ae578dbf8" />

After
<img width="282" height="246" alt="Screenshot 2026-02-06 at 12 10 48" src="https://github.com/user-attachments/assets/5bb49f3b-4483-4501-871b-3d735b9ba2b2" />

