### PR TITLE
Add .gitignore entries for sensitive files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,6 @@ config.local.yaml
 .garmin_token_store
 .env
 .env.*
-*.pem
-*.key
-*.p12
-credentials.json
 
 # Python
 .venv/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 config.local.yaml
 .strava_token.json
 .garmin_token_store
+.env
+.env.*
+*.pem
+*.key
+*.p12
+credentials.json
 
 # Python
 .venv/


### PR DESCRIPTION
The .gitignore is missing entries for `.env` files and private keys (`*.pem`, `*.key`). Added those along with `*.p12` and `credentials.json` to help prevent accidental commits of credentials.